### PR TITLE
Changed how we call the class and how we get the uri

### DIFF
--- a/glue.php
+++ b/glue.php
@@ -36,29 +36,35 @@
          * the main static function of the glue class.
          *
          * @param   array    	$urls  	    The regex-based url to class mapping
+         * @param   string      $directory  The name of the directory that the script is in
          * @throws  Exception               Thrown if corresponding class is not found
          * @throws  Exception               Thrown if no match is found
          * @throws  BadMethodCallException  Thrown if a corresponding GET,POST is not found
          *
          */
-        static function stick ($urls) {
+        static function stick ($urls, $directory) {
 
-            $method = strtoupper($_SERVER['REQUEST_METHOD']);
-            $path = $_SERVER['REQUEST_URI'];
+            $method = $_SERVER['REQUEST_METHOD'];
+            
+            $path = trim(str_replace('/'.trim($directory, '/').'/', '', parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)), '/');
 
             $found = false;
 
             krsort($urls);
 
             foreach ($urls as $regex => $class) {
-                $regex = str_replace('/', '\/', $regex);
-                $regex = '^' . $regex . '\/?$';
-                if (preg_match("/$regex/i", $path, $matches)) {
+                $regex = str_replace('/', '\/', trim($regex, '/'));
+                if (preg_match("/^$regex\$/i", $path, $matches)) {
                     $found = true;
                     if (class_exists($class)) {
                         $obj = new $class;
                         if (method_exists($obj, $method)) {
-                            $obj->$method($matches);
+                            // The first element of matches will be the entire uri
+                            if ( isset($matches[0]) )
+                            {
+                                unset($matches[0]);
+                            }
+                            call_user_func_array(array($obj,$method), $matches);
                         } else {
                             throw new BadMethodCallException("Method, $method, not supported.");
                         }


### PR DESCRIPTION
Removed unnecessary `strtoupper` to `$_SERVER['REQUEST_METHOD']`.

Added `$directory` parameter on `glue::stick` to use the script into a directory, before that was impossible to use glue into a directory (`http://yourpage.com/somedir`).

Added `parse_url` then now we can use `get` parameters on the routes.

Added `trim` to `$path` and `$regex` to fix error when the uri is `/some` and the route is `/some/`.

Changed `$obj->$method($matches)` to `call_user_func_array(array($obj,$method), $matches)` then if we add something like `array('/user/(\w+)-(\d+)' => 'user')` we can do 

class user{ 

function GET($username, $userid){ 

echo 'The id of '.$username.' is '.$userid;

 }

 }
