### PR TITLE
Not really a pull request, just a completly different way to approach glue

### DIFF
--- a/glue.php
+++ b/glue.php
@@ -1,35 +1,35 @@
 <?php
-
     /**
      * glue
      *
-     * Provides an easy way to map URLs to classes. URLs can be literal
+     * Provides an easy way to map URLs to controller files. URLs can be literal
      * strings or regular expressions.
      *
+     *
+     *    
      * When the URLs are processed:
-     *      * delimiter (/) are automatically escaped: (\/)
+     *      * deliminators (/) are automatically escaped: (\/)
      *      * The beginning and end are anchored (^ $)
      *      * An optional end slash is added (/?)
      *	    * The i option is added for case-insensitive searches
+     *	    * Ignores get variables at the end of the URI
      *
      * Example:
      *
      * $urls = array(
      *     '/' => 'index',
-     *     '/page/(\d+)' => 'page'
+     *     '/page/(\d+) => 'page'
      * );
      *
-     * class page {
-     *      function GET($matches) {
-     *          echo "Your requested page " . $matches[1];
-     *      }
-     * }
+     * FILE: ./controllers/page.php
+     * <?php
+     *     echo "Your requested page " . $matches[1];
+     * 
      *
-     * glue::stick($urls);
+     * glue::stick($urls, './controllers/');
      *
      */
     class glue {
-
         /**
          * stick
          *
@@ -41,35 +41,44 @@
          * @throws  BadMethodCallException  Thrown if a corresponding GET,POST is not found
          *
          */
-        static function stick ($urls) {
-
-            $method = strtoupper($_SERVER['REQUEST_METHOD']);
+        static function stick ($urls, $controller_path, $smarty=null, $pagenotfound=null ) {
             $path = $_SERVER['REQUEST_URI'];
-
             $found = false;
-
             krsort($urls);
-
-            foreach ($urls as $regex => $class) {
+            
+            if (!is_dir($controller_path)) {
+                throw new Exception("Path, $controller_path, is not a valid directory!");
+            }
+            
+            foreach ($urls as $regex => $method) {
                 $regex = str_replace('/', '\/', $regex);
-                $regex = '^' . $regex . '\/?$';
+                $regex = '^' . $regex . '(\/)?' . '(\?[a-zA-Z0-9]+=.*)?' . '$';
                 if (preg_match("/$regex/i", $path, $matches)) {
                     $found = true;
-                    if (class_exists($class)) {
-                        $obj = new $class;
-                        if (method_exists($obj, $method)) {
-                            $obj->$method($matches);
-                        } else {
-                            throw new BadMethodCallException("Method, $method, not supported.");
-                        }
+                    $file_path = $controller_path . $method . ".php";
+                    if(substr($method, -4) == ".tpl") { // Quick load template
+                        $smarty->display($method);
+                        break; 
+                    }
+                    if (file_exists($file_path)) {
+                        include($file_path);
                     } else {
-                        throw new Exception("Class, $class, not found.");
+                        if ($pagenotfound == null) {
+                            throw new Exception("Controller file, $file_path, not found!");
+                        } else {
+                            include($controller_path . $pagenotfound . ".php");
+                        }
                     }
                     break;
                 }
             }
             if (!$found) {
-                throw new Exception("URL, $path, not found.");
+                if ($pagenotfound == null) {
+                    throw new Exception("URL, $path, not found.");
+                }
+                else {
+                    include($controller_path . $pagenotfound . ".php");
+                }
             }
         }
     }


### PR DESCRIPTION
I don't think glue should be coupled with a templating library by default so this isn't a pull request, but I just wanted to show you some changes I made to glue for my production product that really helped me.

You might consider making some of them for the next version.
1. In order for Smarty (my template engine) to be in scope for my controllers without using global variables, so I had to couple it with glue by passing it though.
2. I wanted glue::stick to be the last line of my index.php file, so I included the pagenotfound controller in there.
3. I was writing a TON of boilerplate (see route and then go to file) so I mapped paths to files instead. Really cleaned up things.
4. Then had a lot of files that only did $smarty->display('template.tpl') so I had glue look for the .tpl at the controller regular expression, and just run $smarty->display(path) instead. This cleaned up things a ton.
5. For some reason GET variables were not ignored in your version of glue, so I changed the regular expression to filter those out
