### PR TITLE
Allow object to be passed instead of class names

### DIFF
--- a/glue.php
+++ b/glue.php
@@ -35,7 +35,7 @@
          *
          * the main static function of the glue class.
          *
-         * @param   array    	$urls  	    The regex-based url to class mapping
+         * @param   array    	$urls  	    The regex-based url to class or object mapping
          * @throws  Exception               Thrown if corresponding class is not found
          * @throws  Exception               Thrown if no match is found
          * @throws  BadMethodCallException  Thrown if a corresponding GET,POST is not found
@@ -55,8 +55,8 @@
                 $regex = '^' . $regex . '\/?$';
                 if (preg_match("/$regex/i", $path, $matches)) {
                     $found = true;
-                    if (class_exists($class)) {
-                        $obj = new $class;
+                    if (is_object($class) || class_exists($class)) {
+                        $obj = is_object($class) ? $class : new $class;
                         if (method_exists($obj, $method)) {
                             $obj->$method($matches);
                         } else {


### PR DESCRIPTION
I know you said you don't accept pull requests, but this is a really tiny one that gives much value. It lets build you controllers dynamically, for example:

``` php
class ViewRenderer {
  public function __construct($path) {
    $this->path = $path;
  }
  public function GET() {
    // render $this->path
  }
}

glue::stick(array(
  'about' => new ViewRenderer('about.tpl')
));
```

You could eliminate a lot of boilerplate by writing dynamic controllers for common needs, and just configuring them each time. And its a really tiny change :)
