### PR TITLE
Added differentiation to exception types so we can programmatically handle 404s and other errors

### DIFF
--- a/glue.php
+++ b/glue.php
@@ -63,13 +63,13 @@
                             throw new BadMethodCallException("Method, $method, not supported.");
                         }
                     } else {
-                        throw new Exception("Class, $class, not found.");
+                        throw new InvalidArgumentException("Class, $class, not found.");
                     }
                     break;
                 }
             }
             if (!$found) {
-                throw new Exception("URL, $path, not found.");
+                throw new UnexpectedValueException("URL, $path, not found.");
             }
         }
     }


### PR DESCRIPTION
...dling of unimplemented classes or 404 errors.

For example:

```
try {
    glue::stick($urls);
}
catch(UnexpectedValueException $e) {
    handle404();
}
```
